### PR TITLE
Add annotations support for deployments and services

### DIFF
--- a/charts/supabase/templates/analytics/deployment.yaml
+++ b/charts/supabase/templates/analytics/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.analytics.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.analytics.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.analytics.autoscaling.enabled }}
   replicas: {{ .Values.analytics.replicaCount }}

--- a/charts/supabase/templates/analytics/service.yaml
+++ b/charts/supabase/templates/analytics/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.analytics.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.analytics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.analytics.service.type }}
   ports:

--- a/charts/supabase/templates/auth/deployment.yaml
+++ b/charts/supabase/templates/auth/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.auth.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.auth.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.auth.autoscaling.enabled }}
   replicas: {{ .Values.auth.replicaCount }}

--- a/charts/supabase/templates/auth/service.yaml
+++ b/charts/supabase/templates/auth/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.auth.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.auth.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.auth.service.type }}
   ports:

--- a/charts/supabase/templates/db/deployment.yaml
+++ b/charts/supabase/templates/db/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.db.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.db.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.db.autoscaling.enabled }}
   replicas: {{ .Values.db.replicaCount }}

--- a/charts/supabase/templates/db/service.yaml
+++ b/charts/supabase/templates/db/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.db.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.db.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.db.service.type }}
   ports:

--- a/charts/supabase/templates/functions/deployment.yaml
+++ b/charts/supabase/templates/functions/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.functions.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.functions.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.functions.autoscaling.enabled }}
   replicas: {{ .Values.functions.replicaCount }}

--- a/charts/supabase/templates/functions/service.yaml
+++ b/charts/supabase/templates/functions/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.functions.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.functions.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.functions.service.type }}
   ports:

--- a/charts/supabase/templates/imgproxy/deployment.yaml
+++ b/charts/supabase/templates/imgproxy/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.imgproxy.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.imgproxy.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.imgproxy.autoscaling.enabled }}
   replicas: {{ .Values.imgproxy.replicaCount }}

--- a/charts/supabase/templates/imgproxy/service.yaml
+++ b/charts/supabase/templates/imgproxy/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.imgproxy.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.imgproxy.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.imgproxy.service.type }}
   ports:

--- a/charts/supabase/templates/kong/deployment.yaml
+++ b/charts/supabase/templates/kong/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.kong.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.kong.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.kong.autoscaling.enabled }}
   replicas: {{ .Values.kong.replicaCount }}

--- a/charts/supabase/templates/kong/service.yaml
+++ b/charts/supabase/templates/kong/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.kong.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.kong.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.kong.service.type }}
   ports:

--- a/charts/supabase/templates/meta/deployment.yaml
+++ b/charts/supabase/templates/meta/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.meta.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.meta.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.meta.autoscaling.enabled }}
   replicas: {{ .Values.meta.replicaCount }}

--- a/charts/supabase/templates/meta/service.yaml
+++ b/charts/supabase/templates/meta/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.meta.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.meta.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.meta.service.type }}
   ports:

--- a/charts/supabase/templates/minio/deployment.yaml
+++ b/charts/supabase/templates/minio/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.minio.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.minio.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.minio.autoscaling.enabled }}
   replicas: {{ .Values.minio.replicaCount }}

--- a/charts/supabase/templates/minio/service.yaml
+++ b/charts/supabase/templates/minio/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.minio.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.minio.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.minio.service.type }}
   ports:

--- a/charts/supabase/templates/realtime/deployment.yaml
+++ b/charts/supabase/templates/realtime/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.realtime.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.realtime.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.realtime.autoscaling.enabled }}
   replicas: {{ .Values.realtime.replicaCount }}

--- a/charts/supabase/templates/realtime/service.yaml
+++ b/charts/supabase/templates/realtime/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.realtime.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.realtime.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.realtime.service.type }}
   ports:

--- a/charts/supabase/templates/rest/deployment.yaml
+++ b/charts/supabase/templates/rest/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.rest.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.rest.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.rest.autoscaling.enabled }}
   replicas: {{ .Values.rest.replicaCount }}

--- a/charts/supabase/templates/rest/service.yaml
+++ b/charts/supabase/templates/rest/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.rest.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.rest.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.rest.service.type }}
   ports:

--- a/charts/supabase/templates/storage/deployment.yaml
+++ b/charts/supabase/templates/storage/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.storage.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.storage.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.storage.autoscaling.enabled }}
   replicas: {{ .Values.storage.replicaCount }}

--- a/charts/supabase/templates/storage/service.yaml
+++ b/charts/supabase/templates/storage/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.storage.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.storage.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.storage.service.type }}
   ports:

--- a/charts/supabase/templates/studio/deployment.yaml
+++ b/charts/supabase/templates/studio/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.studio.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.studio.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.studio.autoscaling.enabled }}
   replicas: {{ .Values.studio.replicaCount }}

--- a/charts/supabase/templates/studio/service.yaml
+++ b/charts/supabase/templates/studio/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.studio.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.studio.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.studio.service.type }}
   ports:

--- a/charts/supabase/templates/vector/deployment.yaml
+++ b/charts/supabase/templates/vector/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
     vector.dev/exclude: "true"
+  {{- with .Values.vector.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.vector.autoscaling.enabled }}
   replicas: {{ .Values.vector.replicaCount }}

--- a/charts/supabase/templates/vector/service.yaml
+++ b/charts/supabase/templates/vector/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "supabase.vector.fullname" . }}
   labels:
     {{- include "supabase.labels" . | nindent 4 }}
+  {{- with .Values.vector.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.vector.service.type }}
   ports:

--- a/charts/supabase/values.yaml
+++ b/charts/supabase/values.yaml
@@ -116,7 +116,10 @@ db:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 5432
   environment:
@@ -202,7 +205,10 @@ studio:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 3000
   environment:
@@ -277,7 +283,10 @@ auth:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 9999
   environment:
@@ -377,7 +386,10 @@ rest:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 3000
   environment:
@@ -454,7 +466,10 @@ realtime:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 4000
   environment:
@@ -536,7 +551,10 @@ meta:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 8080
   environment:
@@ -611,7 +629,10 @@ storage:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 5000
   environment:
@@ -706,7 +727,10 @@ imgproxy:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 5001
   environment:
@@ -786,7 +810,10 @@ kong:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 8000
   environment:
@@ -881,7 +908,10 @@ analytics:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 4000
   environment:
@@ -965,7 +995,10 @@ vector:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 9001
   # volumeMounts:
@@ -1032,7 +1065,10 @@ functions:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 9000
   environment:
@@ -1106,7 +1142,10 @@ minio:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
+  deployment:
+    annotations: {}
   service:
+    annotations: {}
     type: ClusterIP
     port: 9000
   environment: {}


### PR DESCRIPTION
## Summary
- allow setting annotations for all service and deployment resources
- expose `deployment.annotations` and `service.annotations` keys in values.yaml